### PR TITLE
test: 修复 Clerk publishableKey 缺失导致的构建失败

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -125,12 +125,13 @@ jobs:
         run: npx vercel@47.0.5 link --token=${{ secrets.VERCEL_TOKEN }} --yes --project=v0-gap-drill-error-notebook
         
       - name: 🔧 Pull Vercel Environment Variables
-        run: npx vercel@47.0.5 env pull .env.ci --token=${{ secrets.VERCEL_TOKEN }} --yes
+        run: npx vercel@47.0.5 env pull .env.production --environment=production --token=${{ secrets.VERCEL_TOKEN }} --yes
         
       - name: 🏗️ Build application
         run: npm run build
         env:
           NEXT_TELEMETRY_DISABLED: 1
+          NODE_ENV: production
         timeout-minutes: 8
           
       - name: 📈 Bundle size check
@@ -190,10 +191,12 @@ jobs:
         run: npx vercel@47.0.5 link --token=${{ secrets.VERCEL_TOKEN }} --yes --project=v0-gap-drill-error-notebook
         
       - name: 🔧 Pull Vercel Environment Variables for CodeQL
-        run: npx vercel@47.0.5 env pull .env.ci --token=${{ secrets.VERCEL_TOKEN }} --yes
+        run: npx vercel@47.0.5 env pull .env.production --environment=production --token=${{ secrets.VERCEL_TOKEN }} --yes
           
       - name: 🏗️ Autobuild
         uses: github/codeql-action/autobuild@v3
+        env:
+          NODE_ENV: production
           
       - name: 🔍 Perform CodeQL Analysis
         uses: github/codeql-action/analyze@v3


### PR DESCRIPTION
## 🎯 测试目的

验证通过修复 Vercel 环境变量拉取机制来解决 Clerk publishableKey 缺失问题。

## 🔧 核心修改

1. **修复 Vercel 环境变量拉取**:
   - `.env.ci` → `.env.production --environment=production`
   - 确保拉取的是 production 环境的 Clerk 密钥

2. **设置正确的 NODE_ENV**:
   - 添加 `NODE_ENV: production` 确保 Next.js 加载 `.env.production`

## 🧪 预期结果

构建应该成功，不再出现：
```
Error: @clerk/clerk-react: Missing publishableKey
```

## 🔍 验证点

- [ ] Vercel 环境变量成功拉取
- [ ] Next.js 构建过程中能找到 NEXT_PUBLIC_CLERK_PUBLISHABLE_KEY
- [ ] ClerkProvider 正常初始化
- [ ] 整体构建流程成功

🤖 Generated with [Claude Code](https://claude.ai/code)