### PR TITLE
🔧 Fix ESLint configuration warnings with modern ESM approach

### DIFF
--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -1,5 +1,11 @@
-const { FlatCompat } = require("@eslint/eslintrc");
-const js = require("@eslint/js");
+import { FlatCompat } from "@eslint/eslintrc";
+import js from "@eslint/js";
+import tsParser from "@typescript-eslint/parser";
+import { dirname } from "path";
+import { fileURLToPath } from "url";
+
+const __filename = fileURLToPath(import.meta.url);
+const __dirname = dirname(__filename);
 
 const compat = new FlatCompat({
     baseDirectory: __dirname,
@@ -7,7 +13,7 @@ const compat = new FlatCompat({
     allConfig: js.configs.all
 });
 
-module.exports = [
+const config = [
     // Consolidated ignore patterns
     {
         ignores: [
@@ -19,9 +25,9 @@ module.exports = [
             "**/dist/**",
             "**/.vercel/**",
             "**/coverage/**",
-            "**/types/**",
-            "**/*.config.js",
-            "**/*.config.mjs",
+            "types/**",
+            "next.config.mjs",
+            "postcss.config.mjs",
         ],
     },
     
@@ -37,12 +43,12 @@ module.exports = [
     languageOptions: {
         ecmaVersion: 2024,
         sourceType: "module",
-        parser: require("@typescript-eslint/parser"),
+        parser: tsParser,
         parserOptions: {
             ecmaFeatures: {
                 jsx: true,
             },
-            project: "./tsconfig.json",
+            project: "./tsconfig.eslint.json",
             tsconfigRootDir: __dirname,
         },
     },
@@ -87,3 +93,5 @@ module.exports = [
         "react/jsx-no-target-blank": "error",
     },
 }];
+
+export default config;

--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -94,4 +94,5 @@ const config = [
     },
 }];
 
+// 测试注释
 export default config;

--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -94,5 +94,4 @@ const config = [
     },
 }];
 
-// 测试注释
 export default config;

--- a/tsconfig.eslint.json
+++ b/tsconfig.eslint.json
@@ -1,0 +1,12 @@
+{
+  "extends": "./tsconfig.json",
+  "include": [
+    "next-env.d.ts",
+    "**/*.ts",
+    "**/*.tsx",
+    "**/*.js",
+    "**/*.jsx",
+    ".next/types/**/*.ts"
+  ],
+  "exclude": ["node_modules", ".next", "out"]
+}


### PR DESCRIPTION
## Summary
- Fix ESLint warning: "File ignored because of a matching ignore pattern"
- Modernize ESLint configuration with proper ESM format
- Eliminate all ESLint warnings without suppressing them

## Problem Analysis
The warning occurred because:
1. `eslint.config.js` used CommonJS `require()` syntax
2. TypeScript strict mode conflicts with CommonJS in config files  
3. Broad ignore patterns `**/*.config.js` caused self-ignoring issues

## Solution Implemented
### ✅ **Convert to ESM Configuration**
- Rename `eslint.config.js` → `eslint.config.mjs`
- Replace `require()` with proper ESM imports
- Use `import.meta.url` for `__dirname` equivalent

### ✅ **Create Dedicated TypeScript Config**
- Add `tsconfig.eslint.json` extending main config
- Include JS/TS files needed for ESLint parsing
- Prevent parser configuration errors

### ✅ **Optimize Ignore Patterns**
- Replace `**/*.config.mjs` with specific files
- Use precise paths: `next.config.mjs`, `postcss.config.mjs`
- Allow ESLint config to be properly linted

## Benefits
- 🎯 **Zero warnings** - Proper solution, not suppression
- 🚀 **Modern standards** - ESM is industry best practice for new configs
- 🔧 **Better tooling** - Improved IDE support and maintainability
- ✅ **Future-proof** - Aligns with ESLint 9.x recommendations

## Test Plan
- [x] ESLint config file passes without warnings
- [x] All project files lint successfully  
- [x] Pre-commit hooks execute properly
- [x] TypeScript compilation works correctly
- [x] No breaking changes to existing functionality

## Technical Details
**Before**: CommonJS with broad ignore patterns causing self-reference warnings
**After**: Clean ESM configuration with precise file targeting

This follows ESLint flat config best practices and eliminates the need for warning suppression flags like `--no-warn-ignored`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)