### PR TITLE
feat: Add TypeScript safety and React key ESLint rules

### DIFF
--- a/app/page.tsx
+++ b/app/page.tsx
@@ -331,10 +331,10 @@ export default function HomePage() {
 
                 <h3 className="text-2xl font-bold text-card-foreground mb-3">{t.uploadTitle}</h3>
                 <p className="text-muted-foreground mb-10 text-lg max-w-md mx-auto leading-relaxed">
-                  {t.uploadSubtitle.split('\n').map((line, index) => (
-                    <span key={index}>
+                  {t.uploadSubtitle.split('\n').map((line, index, array) => (
+                    <span key={`upload-subtitle-${line}`}>
                       {line}
-                      {index < t.uploadSubtitle.split('\n').length - 1 && <br />}
+                      {index < array.length - 1 && <br />}
                     </span>
                   ))}
                 </p>

--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -80,6 +80,8 @@ const config = [
 
       // TypeScript specific rules
       '@typescript-eslint/no-unsafe-assignment': 'error',
+      '@typescript-eslint/no-unsafe-call': 'error',
+      '@typescript-eslint/no-unsafe-member-access': 'error',
 
       // Async/Promise safety rules (Critical for production)
       '@typescript-eslint/no-floating-promises': 'error',
@@ -91,6 +93,7 @@ const config = [
       'react/react-in-jsx-scope': 'off',
       'react/prop-types': 'off',
       'react-hooks/exhaustive-deps': 'warn',
+      'react/no-array-index-key': 'error',
 
       // React security rules
       'react/jsx-no-target-blank': 'error',


### PR DESCRIPTION
## Summary
- Add `@typescript-eslint/no-unsafe-call` rule to prevent calling any-typed values
- Add `@typescript-eslint/no-unsafe-member-access` to prevent accessing any-typed properties  
- Add `react/no-array-index-key` to prevent using array indices as React keys
- Fix existing array index key usage in upload subtitle rendering

## Test plan
- [x] ESLint configuration updated with new rules
- [x] Existing codebase passes all new lint rules  
- [x] Pre-commit hooks validate changes successfully
- [x] TypeScript compilation succeeds
- [x] All existing tests pass

These rules enhance type safety and React best practices by catching potential runtime errors at lint time.

🤖 Generated with [Claude Code](https://claude.com/claude-code)