### PR TITLE
🔒 Enhance TypeScript safety with no-explicit-any ESLint rule

### DIFF
--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -80,6 +80,7 @@ const config = [
 
       // TypeScript specific rules
       '@typescript-eslint/no-unsafe-assignment': 'error',
+      '@typescript-eslint/no-explicit-any': 'error',
 
       // Async/Promise safety rules (Critical for production)
       '@typescript-eslint/no-floating-promises': 'error',


### PR DESCRIPTION
## Summary
- Add `@typescript-eslint/no-explicit-any` rule to ESLint configuration
- Prevents explicit usage of `any` type to maintain strict type safety
- Aligns with project core principle: "Types over runtime assumptions"

## Rationale
- Project uses TypeScript strict mode (`tsconfig.json:7`)
- Existing `@typescript-eslint/no-unsafe-assignment` rule is incomplete without `no-explicit-any`
- Prevents developers from bypassing type safety with explicit `any` declarations
- Supports zero-warning lint policy (`package.json:20`)

## Test plan
- [x] ESLint configuration validated successfully
- [x] No existing `any` types detected in current codebase
- [x] Rule properly integrated with existing TypeScript ESLint setup

🤖 Generated with [Claude Code](https://claude.com/claude-code)