### PR TITLE
feat: 添加上传文件的数据库记录功能

### DIFF
--- a/app/api/upload/route.ts
+++ b/app/api/upload/route.ts
@@ -2,6 +2,7 @@ import { handleUpload, type HandleUploadBody } from '@vercel/blob/client'
 import { auth } from '@clerk/nextjs/server'
 import { NextResponse } from 'next/server'
 import { UPLOAD_CONFIG } from '@/lib/constants'
+import { createUpload } from '@/lib/internal-db'
 
 export async function POST(request: Request): Promise<NextResponse> {
   try {
@@ -28,10 +29,11 @@ export async function POST(request: Request): Promise<NextResponse> {
           callbackUrl: `${baseUrl}/api/upload`,
         }
       },
-      onUploadCompleted: ({ blob }) => {
+      onUploadCompleted: async ({ blob }) => {
         // TODO: Add database logging if needed
         // eslint-disable-next-line no-console
         console.log('finished uploaded image url:', blob.url)
+        await createUpload({ imageUrl: blob.url })
         return Promise.resolve()
       },
     })


### PR DESCRIPTION
## 变更内容

- 导入 `createUpload` 函数用于数据库记录
- 将 `onUploadCompleted` 回调改为异步函数  
- 在文件上传完成后调用 `createUpload` 保存图片 URL

## 技术细节

修改文件：`app/api/upload/route.ts`

当用户上传图片完成后，系统会自动将图片 URL 记录到数据库中，方便后续查询和管理。

## 测试

- [x] 修复了 ESLint 错误
- [x] Pre-commit hooks 通过